### PR TITLE
Corrected classname for text selection demo.

### DIFF
--- a/snippets/custom-text-selection.md
+++ b/snippets/custom-text-selection.md
@@ -11,7 +11,7 @@ Changes the styling of text selection.
 #### CSS
 
 ```css
-.text-selection::selection {
+.custom-text-selection::selection {
   background: red;
   color: white;
 }


### PR DESCRIPTION
Discrepancy between example HTML and CSS classnames. I chose the one used in the demo/html.
<img width="627" alt="screen shot 2018-02-25 at 8 27 03 am" src="https://user-images.githubusercontent.com/92724/36643826-c0b3a4e2-1a05-11e8-8402-f5558c77dc83.png">
