### PR TITLE
[FIX] Addition of meta description

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>30 Seconds of CSS</title>
+    <meta name="description" content="A curated collection of useful CSS snippets you can understand in 30 seconds or less. From foundational elements such as clearfix to gradient text color and gradient cursor tracking to CSS easing and far beyond.">
     <link rel="icon" type="image/png" sizes="32x32" href="./favicon-32x32.png">
     <script src="./src/js/index.js" defer=""></script>
     <script async="" defer="" src="https://buttons.github.io/buttons.js"></script>


### PR DESCRIPTION
Let's optimize this site for search. Getting lots of traction here, wanting to help you have it discovered organically, more, too!

The current meta description is pulling from main element, starting with Clearfix section/snippet, since no explicit meta description is provided.

No real search value within the current SERP, here: 
<img width="657" alt="30-seconds-of-css-serp" src="https://user-images.githubusercontent.com/25587929/36804227-28c70f38-1c77-11e8-8ac8-29b56b1766c9.png">

This PR/commit adds a meta description to this project site. Let me know if looking for a different description, I simply wrote based off what's currently on-page and with optimizations for specific, searched terms in-mind ;-)