### PR TITLE
[FEATURE] Live editing

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -40,6 +40,8 @@ for (const snippetFile of fs.readdirSync(SNIPPETS_PATH)) {
   const snippetTemplate = template(markdown)
   const el = createElement(snippetTemplate)
   snippetContainer.append(el)
+  
+  el.querySelectorAll('pre').forEach(el => el.setAttribute('contenteditable', ''))
 
   sidebarLinks.append(
     createElement(

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -41,7 +41,7 @@ for (const snippetFile of fs.readdirSync(SNIPPETS_PATH)) {
   const el = createElement(snippetTemplate)
   snippetContainer.append(el)
   
-  el.querySelectorAll('pre').forEach(el => el.setAttribute('contenteditable', ''))
+  el.querySelectorAll('h4[data-type="CSS"] + pre').forEach(el => el.setAttribute('contenteditable', ''))
 
   sidebarLinks.append(
     createElement(

--- a/src/css/components/base.scss
+++ b/src/css/components/base.scss
@@ -21,6 +21,15 @@ a {
   }
 }
 
+pre {
+  transition: box-shadow 0.1s ease-out;
+  
+  &:focus {
+    outline: 0;
+    box-shadow: 0 0 0 2px #7983ff;
+  }
+}
+
 hr {
   border: 0;
   border-top: 1px solid rgba(0, 32, 128, 0.1);
@@ -29,6 +38,15 @@ hr {
 ul,
 ol {
   padding-left: 1.25rem;
+}
+
+::selection {
+  background: #7983ff;
+  color: white;
+}
+::-moz-selection {
+  background: #7983ff;
+  color: white;
 }
 
 .container {

--- a/src/js/components/Code.js
+++ b/src/js/components/Code.js
@@ -1,0 +1,14 @@
+import { selectAll } from '../deps/utils'
+
+selectAll('code.lang-css').forEach(code => {
+  const pre = code.parentNode
+  let raw = code.innerHTML
+  pre.onfocus = () => code.innerHTML = raw
+  pre.onblur = () => {
+    const snippet = code.closest('.snippet')
+    const styleEl = snippet.querySelector('style')
+    raw = code.innerHTML
+    styleEl.innerHTML = raw.replace(/\.(.+?){/g, '.snippet-demo__$1 {')
+    Prism.highlightElement(code)
+  }
+})

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,14 +1,13 @@
-// Deps
-import 'normalize.css'
-import 'prismjs'
-
-// CSS
-import '../css/deps/prism.css'
-import '../css/index.scss'
-
 // Polyfills
 import './deps/polyfills'
 
 // Components
 import Menu from './components/Menu'
 import BackToTopButton from './components/BackToTopButton'
+import Code from './components/Code'
+
+// CSS
+import 'normalize.css'
+import 'prismjs'
+import '../css/deps/prism.css'
+import '../css/index.scss'


### PR DESCRIPTION
**WIP: Not ready yet.** Currently only works when running `dev` due to the existing style tags which aren't bundled in dev mode.

- Uses `contenteditable` on the CSS `<pre>` elements to enable basic text editing.
- `onblur`, it replaces the existing style with user code, using regex to add namespace since it doesn't line up with the demo code

Problems 🐛:

- Not all snippets can have a live edit mode since the code and demo don't line up..., could they be listed as "LIVE" if they do?
- Either that or we enforce demos to match the code?
- `contenteditable` can add junk html inside the code, maybe we prevent all keypresses inside when editing
