### PR TITLE
fix(build): prettier win paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "nodemon -e md,js ./scripts/build.js & parcel",
     "build": "node ./scripts/build.js && npm run prettier && npm run parcel",
     "parcel": "parcel build index.html -d docs/ --public-url ./",
-    "prettier": "prettier --single-quote --no-semi --print-width=100 ./js/index.js --write './src/**/*.js' './src/**/*.scss'"
+    "prettier": "prettier --single-quote --no-semi --print-width=100 ./js/index.js --write \"./src/**/*.js\" \"./src/**/*.scss\""
   },
   "author": "atomiks",
   "license": "MIT",


### PR DESCRIPTION
On windows we can't run build task. It's because of this:
`[error] No matching files. Patterns tried: ./js/index.js './src/**/*.js' './src/**/*.scss' !**/node_modules/** !./node_modules/**`

Well, I know, windows!?!... :)

It's because of not escapping quotes I belive.
If we need the quotes, I can escape the double them.

Win 10
Node ~8

Of course, it runs on a vm. I tested in vagrant/ubuntu.

Also, I have two small questions  :)
- In the same [L10(with the prettier task)](https://github.com/atomiks/30-seconds-of-css/pull/51/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R10), what do we need `./js/index.js` for?
- What about some help instructions on how to npm run tasks on the readme file?